### PR TITLE
Add preceeding slash to k6 script to avoid no route to host error

### DIFF
--- a/layer7-observability/traffic.yaml
+++ b/layer7-observability/traffic.yaml
@@ -67,7 +67,7 @@ spec:
         command:
           - k6
           - run
-          - k6/script.js
+          - /k6/script.js
         env:
         - name: BASE_URI
           value: http://127.0.0.1:80/api


### PR DESCRIPTION
Without this change, the traffic deployment would not start correctly:

<img width="875" alt="Screenshot 2021-02-04 at 10 05 12" src="https://user-images.githubusercontent.com/554604/106877774-0ac7db00-66d1-11eb-84c4-8a5d5033a76d.png">
