### PR TITLE
Replace protocol annotation with CRD

### DIFF
--- a/custom-resource-definitions/hashicups/postgres.yaml
+++ b/custom-resource-definitions/hashicups/postgres.yaml
@@ -41,7 +41,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9102"
         consul.hashicorp.com/connect-inject: "true"
-        consul.hashicorp.com/connect-service-protocol: "tcp"
     spec:
       serviceAccountName: postgres
       containers:
@@ -64,3 +63,12 @@ spec:
       volumes:
         - name: pgdata
           emptyDir: {}
+
+---
+
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: postgres
+spec:
+  protocol: "tcp"


### PR DESCRIPTION
Protocol annotations were deprecated in favour of CRDs.
Without this, postgres pod doesn't get scheduled as it's refused by the mutating webhook.