### PR TITLE
Add demo configuration for quickstart

### DIFF
--- a/service-mesh/deploy/config.yaml
+++ b/service-mesh/deploy/config.yaml
@@ -1,0 +1,19 @@
+global:
+  name: consul
+  datacenter: dc1
+  image: hashicorp/consul:1.9.4
+  metrics:
+    enabled: true
+    enableAgentMetrics: true
+server:
+  replicas: 1
+ui:
+  enabled: true
+connectInject:
+  enabled: true
+controller:
+  enabled: true
+prometheus:
+  enabled: true
+grafana:
+  enabled: true

--- a/service-mesh/deploy/hashicups/frontend.yaml
+++ b/service-mesh/deploy/hashicups/frontend.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    app: frontend
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend
+automountServiceAccountToken: true
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: frontend
+spec:
+  protocol: "http"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-configmap
+data:
+  config: |
+    # /etc/nginx/conf.d/default.conf
+    server {
+        listen       80;
+        server_name  localhost;
+
+        #charset koi8-r;
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        # Proxy pass the api location to save CORS
+        # Use location exposed by Consul connect
+        location /api {
+            proxy_pass http://127.0.0.1:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: frontend
+      app: frontend
+  template:
+    metadata:
+      labels:
+        service: frontend
+        app: frontend
+      annotations:
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service-upstreams: "public-api:8080"
+        consul.hashicorp.com/enable-metrics-merging: "false"
+    spec:
+      serviceAccountName: frontend
+      volumes:
+      - name: config
+        configMap:
+          name: nginx-configmap
+          items:
+          - key: config
+            path: default.conf
+      containers:
+        - name: frontend
+          image: hashicorpdemoapp/frontend:v0.0.3
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true

--- a/service-mesh/deploy/hashicups/postgres.yaml
+++ b/service-mesh/deploy/hashicups/postgres.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postgres
+automountServiceAccountToken: true
+
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: postgres
+spec:
+  protocol: tcp
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: postgres
+      app: postgres
+  template:
+    metadata:
+      labels:
+        service: postgres
+        app: postgres
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9102"
+        consul.hashicorp.com/connect-inject: "true"
+    spec:
+      serviceAccountName: postgres
+      containers:
+        - name: postgres
+          image: hashicorpdemoapp/product-api-db:v0.0.11
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: products
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: password
+          # only listen on loopback so only access is via connect proxy
+          args: ["-c", "listen_addresses=127.0.0.1"]
+          volumeMounts:
+            - mountPath: "/var/lib/postgresql/data"
+              name: "pgdata"
+      volumes:
+        - name: pgdata
+          emptyDir: {}

--- a/service-mesh/deploy/hashicups/postgres.yaml
+++ b/service-mesh/deploy/hashicups/postgres.yaml
@@ -49,6 +49,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9102"
         consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/enable-metrics-merging: "false"
     spec:
       serviceAccountName: postgres
       containers:

--- a/service-mesh/deploy/hashicups/product-api.yaml
+++ b/service-mesh/deploy/hashicups/product-api.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-api
+spec:
+  selector:
+    app: product-api
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: product-api
+automountServiceAccountToken: true
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: product-api
+spec:
+  protocol: "http"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-configmap
+data:
+  config: |
+    {
+      "db_connection": "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable",
+      "bind_address": ":9090",
+      "metrics_address": ":9103"
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-api
+  labels:
+    app: product-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: product-api
+  template:
+    metadata:
+      labels:
+        app: product-api
+      annotations:
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service-upstreams: "postgres:5432"
+        consul.hashicorp.com/enable-metrics-merging: "false"
+    spec:
+      serviceAccountName: product-api
+      volumes:
+      - name: config
+        configMap:
+          name: db-configmap
+          items:
+          - key: config
+            path: conf.json
+      containers:
+        - name: product-api
+          image: hashicorpdemoapp/product-api:v0.0.12
+          ports:
+            - containerPort: 9090
+            - containerPort: 9103
+          env:
+            - name: "CONFIG_FILE"
+              value: "/config/conf.json"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 30
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true

--- a/service-mesh/deploy/hashicups/public-api.yaml
+++ b/service-mesh/deploy/hashicups/public-api.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: public-api
+  labels:
+    app: public-api
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: public-api
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: public-api
+automountServiceAccountToken: true
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: public-api
+spec:
+  protocol: "http"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: public-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: public-api
+      app: public-api
+  template:
+    metadata:
+      labels:
+        service: public-api
+        app: public-api
+      annotations:
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service-upstreams: "product-api:9090"
+        consul.hashicorp.com/enable-metrics-merging: "false"
+    spec:
+      serviceAccountName: public-api
+      containers:
+        - name: public-api
+          image: hashicorpdemoapp/public-api:v0.0.3
+          ports:
+            - containerPort: 8080
+          env:
+            - name: BIND_ADDRESS
+              value: ":8080"
+            - name: PRODUCTS_API_URI
+              value: "http://localhost:9090"


### PR DESCRIPTION
Demo configuration uses Consul 1.9.4. This will be a quick start tutorial for deploying Consul to Kubernetes.