### PR TITLE
Update getting started demo code to support multiple architectures

### DIFF
--- a/service-mesh/deploy/config.yaml
+++ b/service-mesh/deploy/config.yaml
@@ -1,7 +1,8 @@
 global:
   name: consul
   datacenter: dc1
-  image: hashicorp/consul:1.9.4
+  image: hashicorp/consul:1.9.7
+  imageEnvoy: envoyproxy/envoy:v1.16.4
   metrics:
     enabled: true
     enableAgentMetrics: true

--- a/service-mesh/deploy/hashicups/frontend.yaml
+++ b/service-mesh/deploy/hashicups/frontend.yaml
@@ -92,7 +92,7 @@ spec:
             path: default.conf
       containers:
         - name: frontend
-          image: hashicorpdemoapp/frontend:v0.0.3
+          image: hashicorpdemoapp/frontend:v0.0.5
           ports:
             - containerPort: 80
           volumeMounts:

--- a/service-mesh/deploy/hashicups/postgres.yaml
+++ b/service-mesh/deploy/hashicups/postgres.yaml
@@ -12,15 +12,12 @@ spec:
       targetPort: 5432
   selector:
     app: postgres
-
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: postgres
 automountServiceAccountToken: true
-
 ---
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
@@ -28,7 +25,6 @@ metadata:
   name: postgres
 spec:
   protocol: tcp
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -54,7 +50,7 @@ spec:
       serviceAccountName: postgres
       containers:
         - name: postgres
-          image: hashicorpdemoapp/product-api-db:v0.0.11
+          image: hashicorpdemoapp/product-api-db:v0.0.16
           ports:
             - containerPort: 5432
           env:

--- a/service-mesh/deploy/hashicups/product-api.yaml
+++ b/service-mesh/deploy/hashicups/product-api.yaml
@@ -67,7 +67,7 @@ spec:
             path: conf.json
       containers:
         - name: product-api
-          image: hashicorpdemoapp/product-api:v0.0.12
+          image: hashicorpdemoapp/product-api:v0.0.16
           ports:
             - containerPort: 9090
             - containerPort: 9103

--- a/service-mesh/deploy/hashicups/public-api.yaml
+++ b/service-mesh/deploy/hashicups/public-api.yaml
@@ -49,11 +49,11 @@ spec:
       serviceAccountName: public-api
       containers:
         - name: public-api
-          image: hashicorpdemoapp/public-api:v0.0.3
+          image: hashicorpdemoapp/public-api:v0.0.5
           ports:
             - containerPort: 8080
           env:
             - name: BIND_ADDRESS
               value: ":8080"
-            - name: PRODUCTS_API_URI
+            - name: PRODUCT_API_URI
               value: "http://localhost:9090"


### PR DESCRIPTION
The getting started tutorial for Kubernetes needs to support arm64 builds (due to Docker on M1 Mac). Updating the Kubernetes configuration and Helm configuration to use multi-arch Docker images.