### PR TITLE
Updating image versions and adding imageK8S

### DIFF
--- a/service-mesh/deploy/config.yaml
+++ b/service-mesh/deploy/config.yaml
@@ -1,8 +1,9 @@
 global:
   name: consul
   datacenter: dc1
-  image: hashicorp/consul:1.9.7
-  imageEnvoy: envoyproxy/envoy:v1.16.4
+  image: hashicorp/consul:1.10.1
+  imageEnvoy: envoyproxy/envoy:v1.18.3
+  imageK8S: hashicorp/consul:0.26.0
   metrics:
     enabled: true
     enableAgentMetrics: true


### PR DESCRIPTION
Previously by default when installing the Helm chart it would pull the latest version of `consul-k8s` which may be incompatible with the versions of Consul and Envoy listed in the values.yaml. Updating to Consul 1.10