### PR TITLE
Update Helm Config with newest Consul and Consul k8s images

### DIFF
--- a/service-mesh/deploy/config.yaml
+++ b/service-mesh/deploy/config.yaml
@@ -3,7 +3,7 @@ global:
   datacenter: dc1
   image: hashicorp/consul:1.10.3
   imageEnvoy: envoyproxy/envoy:v1.18.4
-  imageK8S: hashicorp/consul-k8s:0.34.1
+  imageK8S: hashicorp/consul-k8s-control-plane:0.34.1
   metrics:
     enabled: true
     enableAgentMetrics: true

--- a/service-mesh/deploy/config.yaml
+++ b/service-mesh/deploy/config.yaml
@@ -1,9 +1,9 @@
 global:
   name: consul
   datacenter: dc1
-  image: hashicorp/consul:1.10.1
-  imageEnvoy: envoyproxy/envoy:v1.18.3
-  imageK8S: hashicorp/consul-k8s:0.26.0
+  image: hashicorp/consul:1.10.3
+  imageEnvoy: envoyproxy/envoy:v1.18.4
+  imageK8S: hashicorp/consul-k8s:0.34.1
   metrics:
     enabled: true
     enableAgentMetrics: true


### PR DESCRIPTION
Consul Helm 0.34.1 requires 0.34.1 of the consul-k8s-control-plane binary and the latest version of Consul 1.10.3.