### PR TITLE
Update hashicups example to work with Transparent Proxies

### DIFF
--- a/layer7-observability/hashicups/frontend.yaml
+++ b/layer7-observability/hashicups/frontend.yaml
@@ -48,7 +48,7 @@ data:
         # Proxy pass the api location to save CORS
         # Use location exposed by Consul connect
         location /api {
-            proxy_pass http://127.0.0.1:8080;
+            proxy_pass http://public-api.default.svc.cluster.local:8080;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";

--- a/layer7-observability/hashicups/frontend.yaml
+++ b/layer7-observability/hashicups/frontend.yaml
@@ -77,8 +77,6 @@ spec:
       labels:
         service: frontend
         app: frontend
-      annotations:
-        consul.hashicorp.com/connect-service-upstreams: "public-api:8080"
     spec:
       serviceAccountName: frontend
       volumes:

--- a/layer7-observability/hashicups/postgres.yaml
+++ b/layer7-observability/hashicups/postgres.yaml
@@ -41,8 +41,6 @@ spec:
       labels:
         service: postgres
         app: postgres
-      annotations:
-        consul.hashicorp.com/connect-inject: "true"
     spec:
       serviceAccountName: postgres
       containers:

--- a/layer7-observability/hashicups/product-api.yaml
+++ b/layer7-observability/hashicups/product-api.yaml
@@ -52,8 +52,6 @@ spec:
     metadata:
       labels:
         app: product-api
-      annotations:
-        consul.hashicorp.com/connect-service-upstreams: "postgres:5432"
     spec:
       serviceAccountName: product-api
       volumes:

--- a/layer7-observability/hashicups/product-api.yaml
+++ b/layer7-observability/hashicups/product-api.yaml
@@ -32,7 +32,7 @@ metadata:
 data:
   config: |
     {
-      "db_connection": "host=localhost port=5432 user=postgres password=password dbname=products sslmode=disable",
+      "db_connection": "host=postgres.default.svc.cluster.local port=5432 user=postgres password=password dbname=products sslmode=disable",
       "bind_address": ":9090",
       "metrics_address": ":9103"
     }

--- a/layer7-observability/hashicups/public-api.yaml
+++ b/layer7-observability/hashicups/public-api.yaml
@@ -53,5 +53,5 @@ spec:
           env:
             - name: BIND_ADDRESS
               value: ":8080"
-            - name: PRODUCTS_API_URI
+            - name: PRODUCT_API_URI
               value: "http://localhost:9090"

--- a/layer7-observability/hashicups/public-api.yaml
+++ b/layer7-observability/hashicups/public-api.yaml
@@ -52,4 +52,4 @@ spec:
             - name: BIND_ADDRESS
               value: ":8080"
             - name: PRODUCT_API_URI
-              value: "http://localhost:9090"
+              value: "http://product-api.default.svc.cluster.local:9090"

--- a/layer7-observability/hashicups/public-api.yaml
+++ b/layer7-observability/hashicups/public-api.yaml
@@ -41,8 +41,6 @@ spec:
       labels:
         service: public-api
         app: public-api
-      annotations:
-        consul.hashicorp.com/connect-service-upstreams: "product-api:9090"
     spec:
       serviceAccountName: public-api
       containers:


### PR DESCRIPTION
This makes the necessary changes to get the Hashicups example working with Transparent Proxies (which now defaults to being on as of the 0.32.0 version of the Helm chart – which is what's used in the [learn guide](https://learn.hashicorp.com/tutorials/consul/kubernetes-layer7-observability)).