### PR TITLE
Update HashiCups intentions

### DIFF
--- a/consul-client-eks/hashicups/intentions.yaml
+++ b/consul-client-eks/hashicups/intentions.yaml
@@ -1,7 +1,7 @@
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
-  name: frontend
+  name: public-api
 spec:
   # Name of the destination service affected by this ServiceIntentions entry
   destination:
@@ -50,18 +50,20 @@ spec:
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
-  name: product-api
+  name: payments
 spec:
   destination:
     name: payments
   sources:
   - name: product-api
     action: allow
+  - name: public-api
+    action: allow
 ---
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
-  name: public-api
+  name: product-api
 spec:
   destination:
     name: product-api


### PR DESCRIPTION
- Allow public-api -> payments
- Update metadata.name to match the destination service

I felt like using the destination service as the metadata.name value was more inline with how the service intentions work, plus made it more intuitive to add the `public-api` as a source of `payments` traffic.