### PR TITLE
Leverage helm-based install and simplify manifests

### DIFF
--- a/api-gateway/api-gw/consul-api-gateway.yaml
+++ b/api-gateway/api-gw/consul-api-gateway.yaml
@@ -1,34 +1,10 @@
-apiVersion: api-gateway.consul.hashicorp.com/v1alpha1
-kind: GatewayClassConfig
-metadata:
-  name: test-gateway-class-config
-spec:
-  useHostPorts: true
-  logLevel: trace
-  consul:
-    scheme: https
-    caSecret: consul-ca-cert
-    ports:
-      http: 8501
-      grpc: 8502
----
-apiVersion: gateway.networking.k8s.io/v1alpha2
-kind: GatewayClass
-metadata:
-  name: test-gateway-class
-spec:
-  controllerName: "hashicorp.com/consul-api-gateway-controller"
-  parametersRef:
-    group: api-gateway.consul.hashicorp.com
-    kind: GatewayClassConfig
-    name: test-gateway-class-config
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
-  name: test-gateway
+  name: example-gateway
 spec:
-  gatewayClassName: test-gateway-class
+  gatewayClassName: consul-api-gateway
   listeners:
   - protocol: HTTPS
     port: 8443

--- a/api-gateway/api-gw/routes.yaml
+++ b/api-gateway/api-gw/routes.yaml
@@ -2,10 +2,10 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
-  name: test-route-1
+  name: example-route-1
 spec:
   parentRefs:
-  - name: test-gateway
+  - name: example-gateway
   rules:
   - matches:
     - path:
@@ -24,10 +24,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
-  name: test-route-2
+  name: example-route-2
 spec:
   parentRefs:
-  - name: test-gateway
+  - name: example-gateway
   rules:
   - matches:
     - path:

--- a/api-gateway/consul/config.yaml
+++ b/api-gateway/consul/config.yaml
@@ -4,17 +4,19 @@ global:
   image: "hashicorp/consul:1.11.2"
   tls:
     enabled: true
-    serverAdditionalDNSSANs:
-    - host.docker.internal
-    - localhost
-    - consul-server.default.svc.cluster.local
 server:
   replicas: 1
 ui:
   enabled: true
   service:
-    type: 'NodePort'
+    type: NodePort
 connectInject:
   enabled: true
 controller:
   enabled: true
+apiGateway:
+  enabled: true
+  image: "hashicorp/consul-api-gateway:0.1.0-beta"
+  managedGatewayClass:
+    serviceType: NodePort
+    useHostPorts: true

--- a/api-gateway/kind/cluster.yaml
+++ b/api-gateway/kind/cluster.yaml
@@ -2,12 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
-  - |
-    kind: InitConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 443
     hostPort: 443


### PR DESCRIPTION
This simplifies much of the tutorial to leverage `helm` instead of using the `kustomize`-based installation method. Tested with:

```bash
kind create cluster --config=kind/cluster.yaml
kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.1.0-beta"
helm install --values consul/config.yaml consul hashicorp/consul --version "0.40.0"
kubectl apply -f two-services
kubectl apply -f api-gw/consul-api-gateway.yaml
kubectl wait --for=condition=ready gateway/example-gateway --timeout=90s && kubectl apply -f api-gw/routes.yaml
```
<img width="1082" alt="Screen Shot 2022-01-27 at 3 53 32 PM" src="https://user-images.githubusercontent.com/3577250/151441966-61aedc71-91f4-4538-8977-2640f8377dd8.png">
<img width="1093" alt="Screen Shot 2022-01-27 at 3 53 44 PM" src="https://user-images.githubusercontent.com/3577250/151441975-a5e197a1-b54b-41c1-b79d-5d539f828f0e.png">

