### PR TITLE
Update gateway name in README command

### DIFF
--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -7,7 +7,7 @@
 6. `helm repo update`
 7. `helm install -f consul/config.yaml consul hashicorp/consul --version "0.40.0"`
 8. `kubectl apply -filename two-services`
-9.  `kubectl apply -f api-gw/consul-api-gateway.yaml && kubectl wait --for=condition=ready gateway/test-gateway --timeout=90s && kubectl apply -f api-gw/routes.yaml` 
+9.  `kubectl apply -f api-gw/consul-api-gateway.yaml && kubectl wait --for=condition=ready gateway/example-gateway --timeout=90s && kubectl apply -f api-gw/routes.yaml` 
 10.  `kubectl port-forward svc/consul-ui 6443:443`
 11. Visit the following urls in the browser
     1.  [https://localhost:6443/ui/](https://localhost:6443/ui/)

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -6,8 +6,8 @@
 5. `helm repo add hashicorp https://helm.releases.hashicorp.com`
 6. `helm repo update`
 7. `helm install -f consul/config.yaml consul hashicorp/consul --version "0.40.0"`
-8. `kubectl apply -filename two-services`
-9.  `kubectl apply -f api-gw/consul-api-gateway.yaml && kubectl wait --for=condition=ready gateway/example-gateway --timeout=90s && kubectl apply -f api-gw/routes.yaml` 
+8. `kubectl apply --filename two-services`
+9.  `kubectl apply --filename api-gw/consul-api-gateway.yaml && kubectl wait --for=condition=ready gateway/example-gateway --timeout=90s && kubectl apply --filename api-gw/routes.yaml` 
 10.  `kubectl port-forward svc/consul-ui 6443:443`
 11. Visit the following urls in the browser
     1.  [https://localhost:6443/ui/](https://localhost:6443/ui/)


### PR DESCRIPTION
The `Gateway` defined [here](https://github.com/hashicorp/learn-consul-kubernetes/blob/53100cd7b6fb58edd1042b9d6489d94eb7a17d3f/api-gateway/api-gw/consul-api-gateway.yaml#L5) had its name updated to `example-gateway`; however, the commands in the README still use the old name, `test-gateway`.

https://github.com/hashicorp/learn-consul-kubernetes/blob/53100cd7b6fb58edd1042b9d6489d94eb7a17d3f/api-gateway/api-gw/consul-api-gateway.yaml#L5