### PR TITLE
Update image and Helm chart references for API Gateway `v0.1.0`

### DIFF
--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -2,10 +2,10 @@
 1. Clone repo
 2. `cd api-gateway/`
 3. `kind create cluster --config=kind/cluster.yaml`
-4. `kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.1.0-beta"`
+4. `kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.1.0"`
 5. `helm repo add hashicorp https://helm.releases.hashicorp.com`
 6. `helm repo update`
-7. `helm install -f consul/config.yaml consul hashicorp/consul --version "0.40.0"`
+7. `helm install -f consul/config.yaml consul hashicorp/consul --version "0.41.0"`
 8. `kubectl apply --filename two-services`
 9.  `kubectl apply --filename api-gw/consul-api-gateway.yaml && kubectl wait --for=condition=ready gateway/example-gateway --timeout=90s && kubectl apply --filename api-gw/routes.yaml` 
 10.  `kubectl port-forward svc/consul-ui 6443:443`

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -5,7 +5,7 @@
 4. `kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.1.0"`
 5. `helm repo add hashicorp https://helm.releases.hashicorp.com`
 6. `helm repo update`
-7. `helm install -f consul/config.yaml consul hashicorp/consul --version "0.41.0"`
+7. `helm install -f consul/config.yaml consul hashicorp/consul --version "0.41.1"`
 8. `kubectl apply --filename two-services`
 9.  `kubectl apply --filename api-gw/consul-api-gateway.yaml && kubectl wait --for=condition=ready gateway/example-gateway --timeout=90s && kubectl apply --filename api-gw/routes.yaml` 
 10.  `kubectl port-forward svc/consul-ui 6443:443`

--- a/api-gateway/api-gw/routes.yaml
+++ b/api-gateway/api-gw/routes.yaml
@@ -14,10 +14,12 @@ spec:
     backendRefs:
     - kind: Service
       name: echo-1
+      namespace: default
       port: 8080
       weight: 50
     - kind: Service
       name: echo-2
+      namespace: default
       port: 8090
       weight: 50
 ---
@@ -36,4 +38,5 @@ spec:
     backendRefs:
     - kind: Service
       name: frontend
+      namespace: default
       port: 80

--- a/api-gateway/consul/config.yaml
+++ b/api-gateway/consul/config.yaml
@@ -16,7 +16,7 @@ controller:
   enabled: true
 apiGateway:
   enabled: true
-  image: "hashicorp/consul-api-gateway:0.1.0-beta"
+  image: "hashicorp/consul-api-gateway:0.1.0"
   managedGatewayClass:
     serviceType: NodePort
     useHostPorts: true


### PR DESCRIPTION
As part of GA release for Consul API Gateway, update the learn resources to use the correct image and Helm chart refs.