### PR TITLE
main, provider, and variable changes

### DIFF
--- a/hcp-consul-hcp-vault-ca/provider.tf
+++ b/hcp-consul-hcp-vault-ca/provider.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.5"
+  required_version = ">= 1.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -20,12 +20,11 @@ provider "aws" {
 }
 
 provider "hcp" {
-  client_id     = var.hcp_client_id
-  client_secret = var.hcp_client_secret
 }
 
 provider "kubernetes" {
-  config_path = "~/.kube/config"
-  config_context = "tutorialCluster"
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
 }
 

--- a/hcp-consul-hcp-vault-ca/variables.tf
+++ b/hcp-consul-hcp-vault-ca/variables.tf
@@ -2,8 +2,8 @@ variable "region" {
   default     = "us-east-1"
   description = "Region in which to run this terraform code for the AWS Provider"
 }
-variable "node_group_configuration" {
 
+variable "node_group_configuration" {
   default = {
     ami_type       = "AL2_x86_64"
     instance_types = ["m5.large"]
@@ -25,38 +25,38 @@ variable "default_tags" {
 }
 
 # Set hcp_client_id and hcp_client_secret values. Configured with TF_VAR environment variables.
-variable "hcp_client_id" {
-  description = "The Client ID of the HCP Service Principal"
-}
-variable "hcp_client_secret" {
-  description = "The Client Secret of the HCP Service Principal"
-}
+#variable "hcp_client_id" {
+#  description = "The Client ID of the HCP Service Principal"
+#}
+#variable "hcp_client_secret" {
+#  description = "The Client Secret of the HCP Service Principal"
+#}
 
 # AWS Credentials to deploy to AWS. Set with TF_VAR environment variables
-variable "aws_secret_id" {
-  description = "AWS Secret ID"
-  type = string
-}
-variable "aws_client_secret" {
-  description = "AWS Client Secret"
-}
+#variable "aws_secret_id" {
+#  description = "AWS Secret ID"
+#  type = string
+#}
+#variable "aws_client_secret" {
+#  description = "AWS Client Secret"
+#}
 
-variable "aws_cidr_block" {
-  description = "CIDR block for AWS"
-  default = {
-    allocation = "172.16.0.0/19"
-    subnets = {
-      private = ["172.16.2.0/24", "172.16.3.0/24"]
-      public  = ["172.16.4.0/24", "172.16.5.0/24"]
-    }
-  }
-}
+#variable "aws_cidr_block" {
+#  description = "CIDR block for AWS"
+#  default = {
+#    allocation = "172.16.0.0/19"
+#    subnets = {
+#      private = ["172.16.2.0/24", "172.16.3.0/24"]
+#      public  = ["172.16.4.0/24", "172.16.5.0/24"]
+#    }
+#  }
+#}
 
 variable "hcp_hvn_config" {
   description = "CIDR block for HCP"
   default = {
-    allocation = "10.100.0.0/19"
-    name       = "hcpTutorial"
+    allocation = "172.25.32.0/20"
+    name       = "hcpTutorial2"
   }
 }
 
@@ -89,8 +89,8 @@ variable "hcp_vault_cluster_name" {
 variable "cluster_info" {
   default = {
     region = "us-east-1"
-    name = "tutorialCluster"
-    vpc_name = "hcpTutorialAwsVpc"
+    name = "tutorialCluster2"
+    vpc_name = "hcpTutorialAwsVpc2"
   }
 }
 


### PR DESCRIPTION
Modified a few of the files based on the example located here:
https://github.com/hashicorp/terraform-aws-hcp-consul/tree/main/examples/hcp-eks-demo

As a result, the deployment succeeded after 15 minutes:

```
Apply complete! Resources: 76 added, 0 changed, 0 destroyed.

Outputs:

consul_cert_data = <sensitive>
eks_cluster_host = "https://14B2FD986455226D19649D08EAA7692F.gr7.us-east-1.eks.amazonaws.com"
eks_data = <sensitive>
vault_data = <sensitive>
```