### PR TITLE
Fix Prometheus URL in the Grafana Dashboard Definition

### DIFF
--- a/layer7-observability/helm/grafana-values.yaml
+++ b/layer7-observability/helm/grafana-values.yaml
@@ -25,7 +25,7 @@ datasources:
       - name: Prometheus
         type: prometheus
         orgId: 1
-        url: prometheus-server.default.svc.cluster.local
+        url: http://prometheus-server.default.svc.cluster.local
         access: proxy
         isDefault: true
         jsonData:


### PR DESCRIPTION
The protocol must be specified for data sources in the most recent grafana chart available at this time (6.23.2).