### PR TITLE
Add ReferencePolicy to allow cross-namespace routing

### DIFF
--- a/api-gateway/two-services/referencepolicy.yaml
+++ b/api-gateway/two-services/referencepolicy.yaml
@@ -1,8 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: ReferencePolicy
 metadata:
-  name: default-namespace-reference-policy
-  namespace: default
+  name: example-reference-policy
 spec:
   from:
     - group: gateway.networking.k8s.io

--- a/api-gateway/two-services/referencepolicy.yaml
+++ b/api-gateway/two-services/referencepolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferencePolicy
+metadata:
+  name: default-namespace-reference-policy
+  namespace: default
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: consul  # Must match the namespace that api-gw/routes.yaml is deployed into
+  to:
+    - group: ""
+      kind: Service


### PR DESCRIPTION
With the (future) release of Consul API Gateway v0.2.0, there must be a `ReferencePolicy` in place to allow a route in one namespace to use a backend/service in a different namespace.

Since the stack defined here does exactly that - `HTTPRoute` in the consul namespace and `Service` in the default namespace - we need to add a `ReferencePolicy` that allows it; otherwise, the example here will be broken in the future.

I chose to include the `ReferencePolicy` in the `two-services/` directory since it needs to live alongside the services that will be routed to, within the same namespace. Alternatively, we could update the Learn guide to draw the practitioner's attention to the policy and install it separately; however, that's a much bigger cross-repo change. If you feel strongly that we should go that route instead, please speak to that by leaving a comment below.

### Testing
I followed the Learn guide [here](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway) but used a build from the `main` branch of [hashicorp/consul-api-gateway](https://github.com/hashicorp/consul-api-gateway) to ensure that the `ReferencePolicy` meets the new requirements and that this stack will continue to work after release.