### PR TITLE
Specify explicit namespace for each CAPIGW k8s resource

### DIFF
--- a/api-gateway/api-gw/consul-api-gateway.yaml
+++ b/api-gateway/api-gw/consul-api-gateway.yaml
@@ -3,6 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:
   name: example-gateway
+  namespace: consul
 spec:
   gatewayClassName: consul-api-gateway
   listeners:

--- a/api-gateway/api-gw/routes.yaml
+++ b/api-gateway/api-gw/routes.yaml
@@ -3,6 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
   name: example-route-1
+  namespace: consul
 spec:
   parentRefs:
   - name: example-gateway
@@ -27,6 +28,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
   name: example-route-2
+  namespace: consul
 spec:
   parentRefs:
   - name: example-gateway

--- a/api-gateway/two-services/echo-1.yaml
+++ b/api-gateway/two-services/echo-1.yaml
@@ -3,6 +3,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
   name: echo-1
+  namespace: default
 spec:
   protocol: http
 ---
@@ -12,6 +13,7 @@ metadata:
   labels:
     app: echo-1
   name: echo-1
+  namespace: default
 spec:
   ports:
   - port: 8080
@@ -25,6 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: echo-1
+  namespace: default
 automountServiceAccountToken: true
 ---
 apiVersion: apps/v1
@@ -33,6 +36,7 @@ metadata:
   labels:
     app: echo-1
   name: echo-1
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/api-gateway/two-services/echo-2.yaml
+++ b/api-gateway/two-services/echo-2.yaml
@@ -3,6 +3,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
   name: echo-2
+  namespace: default
 spec:
   protocol: http
 ---
@@ -12,6 +13,7 @@ metadata:
   labels:
     app: echo-2
   name: echo-2
+  namespace: default
 spec:
   ports:
   - port: 8090
@@ -25,6 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: echo-2
+  namespace: default
 automountServiceAccountToken: true
 ---
 apiVersion: apps/v1
@@ -33,6 +36,7 @@ metadata:
   labels:
     app: echo-2
   name: echo-2
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/api-gateway/two-services/frontend.yaml
+++ b/api-gateway/two-services/frontend.yaml
@@ -3,6 +3,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
   name: frontend
+  namespace: default
 spec:
   protocol: "http"
 ---
@@ -10,6 +11,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
+  namespace: default
   labels:
     app: frontend
 spec:
@@ -26,12 +28,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: frontend
+  namespace: default
 automountServiceAccountToken: true
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-configmap
+  namespace: default
 data:
   config: |
     # /etc/nginx/conf.d/default.conf
@@ -69,6 +73,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
+  namespace: default
   labels:
     app: frontend
 spec:

--- a/api-gateway/two-services/intentions.yaml
+++ b/api-gateway/two-services/intentions.yaml
@@ -2,6 +2,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
   name: public-api
+  namespace: default
 spec:
   # Name of the destination service affected by this ServiceIntentions entry
   destination:
@@ -40,6 +41,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
   name: postgres
+  namespace: default
 spec:
   destination:
     name: postgres
@@ -51,6 +53,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
   name: payments
+  namespace: default
 spec:
   destination:
     name: payments
@@ -64,6 +67,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
   name: product-api
+  namespace: default
 spec:
   destination:
     name: product-api

--- a/api-gateway/two-services/payments.yaml
+++ b/api-gateway/two-services/payments.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: payments
+  namespace: default
 spec:
   selector:
     app: payments
@@ -16,12 +17,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: payments
+  namespace: default
 automountServiceAccountToken: true
 ---
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
   name: payments
+  namespace: default
 spec:
   protocol: "http"
 ---
@@ -29,6 +32,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payments
+  namespace: default
   labels:
     app: payments
 spec:

--- a/api-gateway/two-services/postgres.yaml
+++ b/api-gateway/two-services/postgres.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres
+  namespace: default
   labels:
     app: postgres
 spec:
@@ -17,6 +18,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
   name: postgres
+  namespace: default
 spec:
   protocol: 'tcp'
 ---
@@ -24,12 +26,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: postgres
+  namespace: default
 automountServiceAccountToken: true
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/api-gateway/two-services/product-api.yaml
+++ b/api-gateway/two-services/product-api.yaml
@@ -22,6 +22,7 @@ apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
   name: product-api
+  namespace: default
 spec:
   protocol: "http"
 ---
@@ -42,6 +43,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: product-api
+  namespace: default
   labels:
     app: product-api
 spec:

--- a/api-gateway/two-services/public-api.yaml
+++ b/api-gateway/two-services/public-api.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: public-api
+  namespace: default
   labels:
     app: public-api
 spec:
@@ -17,12 +18,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: public-api
+  namespace: default
 automountServiceAccountToken: true
 ---
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
 metadata:
   name: public-api
+  namespace: default
 spec:
   protocol: "http"
 ---
@@ -30,6 +33,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: public-api
+  namespace: default
 spec:
   replicas: 1
   selector:

--- a/api-gateway/two-services/rbac.yaml
+++ b/api-gateway/two-services/rbac.yaml
@@ -15,8 +15,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  namespace: default
   name: consul-api-gateway-auth
+  namespace: default
 rules:
 - apiGroups:
   - ""

--- a/api-gateway/two-services/referencepolicy.yaml
+++ b/api-gateway/two-services/referencepolicy.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: ReferencePolicy
 metadata:
   name: example-reference-policy
+  namespace: default
 spec:
   from:
     - group: gateway.networking.k8s.io


### PR DESCRIPTION
Conversation around updates for the Consul API Gateway Learn Guide landed on explicitly specifying the namespace for each k8s resource in the tutorial to prevent any confusion when adapting what a practitioner learned from the guide to work in another context.