### PR TITLE
Add liveness probe to product api

### DIFF
--- a/service-mesh/deploy/hashicups/postgres.yaml
+++ b/service-mesh/deploy/hashicups/postgres.yaml
@@ -50,7 +50,7 @@ spec:
       serviceAccountName: postgres
       containers:
         - name: postgres
-          image: hashicorpdemoapp/product-api-db:v0.0.16
+          image: hashicorpdemoapp/product-api-db:v0.0.22
           ports:
             - containerPort: 5432
           env:

--- a/service-mesh/deploy/hashicups/product-api.yaml
+++ b/service-mesh/deploy/hashicups/product-api.yaml
@@ -67,7 +67,7 @@ spec:
             path: conf.json
       containers:
         - name: product-api
-          image: hashicorpdemoapp/product-api:v0.0.16
+          image: hashicorpdemoapp/product-api:v0.0.22
           ports:
             - containerPort: 9090
             - containerPort: 9103
@@ -76,7 +76,12 @@ spec:
               value: "/config/conf.json"
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/livez
+              port: 9090
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health/readyz
               port: 9090
             initialDelaySeconds: 15
             timeoutSeconds: 1

--- a/service-mesh/deploy/hashicups/public-api.yaml
+++ b/service-mesh/deploy/hashicups/public-api.yaml
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: public-api
       containers:
         - name: public-api
-          image: hashicorpdemoapp/public-api:v0.0.5
+          image: hashicorpdemoapp/public-api:v0.0.7
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Follow up to https://github.com/hashicorp-demoapp/product-api-go/pull/27. I tried to update the frontend while I was at it but had problems proxying the `public-api` requests through w/o NGINX.