### PR TITLE
Use arm64-compatible image for Consul API Gateway echo services

### DIFF
--- a/api-gateway/local/two-services/echo-1.yaml
+++ b/api-gateway/local/two-services/echo-1.yaml
@@ -53,5 +53,16 @@ spec:
       containers:
       - image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
         name: echo-1
+        env:
+        - name: SERVICE_NAME
+          value: echo-1
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 3000

--- a/api-gateway/local/two-services/echo-1.yaml
+++ b/api-gateway/local/two-services/echo-1.yaml
@@ -19,7 +19,7 @@ spec:
   - port: 8080
     name: high
     protocol: TCP
-    targetPort: 8080
+    targetPort: 3000
   selector:
     app: echo-1
 ---
@@ -51,7 +51,7 @@ spec:
     spec:
       serviceAccountName: echo-1
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+      - image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
         name: echo-1
         ports:
-        - containerPort: 8080
+        - containerPort: 3000

--- a/api-gateway/local/two-services/echo-2.yaml
+++ b/api-gateway/local/two-services/echo-2.yaml
@@ -19,7 +19,7 @@ spec:
   - port: 8090
     name: high
     protocol: TCP
-    targetPort: 8080
+    targetPort: 3000
   selector:
     app: echo-2
 ---
@@ -51,7 +51,7 @@ spec:
     spec:
       serviceAccountName: echo-2
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+      - image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
         name: echo-2
         ports:
-        - containerPort: 8080
+        - containerPort: 3000

--- a/api-gateway/local/two-services/echo-2.yaml
+++ b/api-gateway/local/two-services/echo-2.yaml
@@ -53,5 +53,16 @@ spec:
       containers:
       - image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
         name: echo-2
+        env:
+        - name: SERVICE_NAME
+          value: echo-2
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 3000

--- a/api-gateway/local/two-services/nginx.yaml
+++ b/api-gateway/local/two-services/nginx.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-config
+  namespace: default
 data:
   nginx.conf: |
     events {}

--- a/api-gateway/local/two-services/product-api.yaml
+++ b/api-gateway/local/two-services/product-api.yaml
@@ -32,6 +32,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: db-configmap
+  namespace: default
 data:
   config: |
     {


### PR DESCRIPTION
Fixes #65 

To test, just follow the [Learn guide](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway) instructions for local/kind using this version of learn-consul-kubernetes.