### PR TITLE
api-gateway: update for v0.4.0 release

### DIFF
--- a/api-gateway/local/api-gw/consul-api-gateway.yaml
+++ b/api-gateway/local/api-gw/consul-api-gateway.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: api-gateway

--- a/api-gateway/local/api-gw/routes.yaml
+++ b/api-gateway/local/api-gw/routes.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: example-route-1

--- a/api-gateway/local/consul/config.yaml
+++ b/api-gateway/local/consul/config.yaml
@@ -15,7 +15,7 @@ controller:
   enabled: true
 apiGateway:
   enabled: true
-  image: "hashicorp/consul-api-gateway:0.3.0"
+  image: "hashicorp/consul-api-gateway:0.4.0"
   managedGatewayClass:
     serviceType: NodePort
     useHostPorts: true

--- a/api-gateway/local/two-services/referencegrant.yaml
+++ b/api-gateway/local/two-services/referencegrant.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
-kind: ReferencePolicy
+kind: ReferenceGrant
 metadata:
-  name: example-reference-policy
+  name: example-reference-grant
   namespace: default
 spec:
   from:


### PR DESCRIPTION
Updates Consul API Gateway image to [not yet released] v0.4.0, updates Gateway and HTTPRoute to v1beta1 and migrates from ReferenceGrant to ReferencePolicy.

Will require corresponding updates over in https://github.com/hashicorp/tutorials/blob/main/content/tutorials/consul/kubernetes-api-gateway.mdx