### PR TITLE
Patch HCP Consul/HCP Vault tutorial

### DIFF
--- a/hcp-consul-hcp-vault-ca/Makefile
+++ b/hcp-consul-hcp-vault-ca/Makefile
@@ -1,6 +1,6 @@
 .PHONY: init
 init:
-	terraform init && terraform -chdir=./working-environment init
+	bash set_region_for_makefile.sh && terraform init && terraform -chdir=./working-environment init
 
 .PHONY: apply
 apply:
@@ -9,4 +9,3 @@ apply:
 .PHONY: destroy
 destroy:
 	terraform -chdir=./working-environment destroy && terraform destroy
-

--- a/hcp-consul-hcp-vault-ca/Makefile
+++ b/hcp-consul-hcp-vault-ca/Makefile
@@ -1,0 +1,12 @@
+.PHONY: init
+init:
+	terraform init && terraform -chdir=./working-environment init
+
+.PHONY: apply
+apply:
+	terraform apply && terraform -chdir=./working-environment apply
+
+.PHONY: destroy
+destroy:
+	terraform -chdir=./working-environment destroy && terraform destroy
+

--- a/hcp-consul-hcp-vault-ca/confirm.sh
+++ b/hcp-consul-hcp-vault-ca/confirm.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+export WORKBENCH=$(kubectl get pods -l app=tutorial  -o json | jq -r ".items[0].metadata.name")
+rc =$(echo $?)
+
+if [ $rc -ne 0 ]
+then
+  echo "Workbench Pod not found. Use kubectl manually, or try again in a moment"
+  exit 1
+fi
 
 echo	"Confirming access to Kubernetes resources"
 kubectl exec -it "${WORKBENCH}" -- kubectl get pods --all-namespaces >/dev/null

--- a/hcp-consul-hcp-vault-ca/confirm.sh
+++ b/hcp-consul-hcp-vault-ca/confirm.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+echo	"Confirming access to Kubernetes resources"
+kubectl exec -it "${WORKBENCH}" -- kubectl get pods --all-namespaces >/dev/null
+krc=$(echo $?)
+sleep 2
+echo	"Confirming access to HCP Consul"
+kubectl exec -it "${WORKBENCH}" -- consul members >/dev/null
+crc=$(echo $?)
+sleep 2
+echo	"Confirming access to HCP Vault"
+kubectl exec -it "${WORKBENCH}" -- vault status >/dev/null
+vrc=$(echo $?)
+if [ $krc -ne 0 ] || [ $crc -ne 0 ] || [ $vrc -ne 0 ]
+then
+  echo "Access failed to one or more resources."
+  echo "Kubernetes returned: $krc"
+  echo "Consul returned $crc"
+  echo "Vault returned $vrc"
+  exit 1
+else
+  echo "Access confirmed!"
+  exit 0
+fi

--- a/hcp-consul-hcp-vault-ca/confirm.sh
+++ b/hcp-consul-hcp-vault-ca/confirm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export WORKBENCH=$(kubectl get pods -l app=tutorial  -o json | jq -r ".items[0].metadata.name")
-rc =$(echo $?)
+rc=$(echo $?)
 
 if [ $rc -ne 0 ]
 then

--- a/hcp-consul-hcp-vault-ca/data.tf
+++ b/hcp-consul-hcp-vault-ca/data.tf
@@ -1,2 +1,9 @@
 # The identity of the AWS User running this terraform project
 data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "current" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}

--- a/hcp-consul-hcp-vault-ca/main.tf
+++ b/hcp-consul-hcp-vault-ca/main.tf
@@ -22,7 +22,7 @@ module "aws_vpc" {
   version            = "3.11.5"
   name               = local.identifier
   cidr               = var.aws_cidr_block.allocation
-  azs                = var.availability_zones
+  azs                = data.aws_availability_zones.current.names
   private_subnets    = var.aws_cidr_block.subnets.private
   public_subnets     = var.aws_cidr_block.subnets.public
   enable_nat_gateway = true
@@ -196,6 +196,6 @@ role_arn="${module.iam_role_for_service_accounts.iam_role_arn}"
 profile_name="${var.profile_name}"
 cluster_service_account_name="${var.kube_service_account_name}"
 cluster_name="${local.eks_name}"
-cluster_region="${var.cluster_and_vpc_info.region}"
+cluster_region="${var.region}"
 CONFIGURATION
 }

--- a/hcp-consul-hcp-vault-ca/main.tf
+++ b/hcp-consul-hcp-vault-ca/main.tf
@@ -134,7 +134,7 @@ module "eks" {
 resource "null_resource" "update_kubeconfig" {
 
   provisioner "local-exec" {
-    command = "aws eks --region ${var.cluster_and_vpc_info.region} update-kubeconfig --name ${module.eks.cluster_id} --alias ${module.eks.cluster_id}"
+    command = "aws eks --region ${var.region} update-kubeconfig --name ${module.eks.cluster_id} --alias ${module.eks.cluster_id}"
   }
   depends_on = [module.eks]
 }
@@ -197,5 +197,6 @@ profile_name="${var.profile_name}"
 cluster_service_account_name="${var.kube_service_account_name}"
 cluster_name="${local.eks_name}"
 cluster_region="${var.region}"
+datacenter="${module.hcp_applications.consul_datacenter}"
 CONFIGURATION
 }

--- a/hcp-consul-hcp-vault-ca/main.tf
+++ b/hcp-consul-hcp-vault-ca/main.tf
@@ -197,6 +197,6 @@ profile_name="${var.profile_name}"
 cluster_service_account_name="${var.kube_service_account_name}"
 cluster_name="${local.eks_name}"
 cluster_region="${var.region}"
-datacenter="${module.hcp_applications.consul_datacenter}"
+consul_datacenter="${module.hcp_applications.consul_datacenter}"
 CONFIGURATION
 }

--- a/hcp-consul-hcp-vault-ca/modules/hcp_applications/outputs.tf
+++ b/hcp-consul-hcp-vault-ca/modules/hcp_applications/outputs.tf
@@ -3,6 +3,11 @@ output "consul_cluster_host" {
   value = hcp_consul_cluster.server.consul_private_endpoint_url
 }
 
+# Consul datacenter name
+output "consul_datacenter" {
+  value = hcp_consul_cluster.server.datacenter
+}
+
 # The Consul config file to setup the working environment
 output "consul_config_file" {
   value = hcp_consul_cluster.server.consul_config_file

--- a/hcp-consul-hcp-vault-ca/modules/kubernetes/main.tf
+++ b/hcp-consul-hcp-vault-ca/modules/kubernetes/main.tf
@@ -50,8 +50,10 @@ resource "kubernetes_config_map" "consul_values" {
   data = {
     "consul-values.yaml" = templatefile("${path.module}/template_scripts/consul-values.tftpl", {
       vault_addr = var.vault_addr
-      hcp_consul_addr = var.consul_http_addr
-      kube_control_plane = var.consul_k8s_api_aws
+      # remove "https://" from the URL for correct format in helm chart
+      hcp_consul_addr = substr(var.consul_http_addr, 8, -1)
+      kube_control_plane = var.consul_k8s_api_aws,
+      datacenter = var.consul_datacenter
     })
   }
 }
@@ -213,7 +215,7 @@ resource "kubernetes_deployment" "workingEnvironment" {
             read_only  = true
           }
           volume_mount {
-            mount_path = "/root/consul-values.yaml"
+            mount_path = "/consul-values.yaml"
             name       = "consul-values"
             sub_path   = "consul-values.yaml"
             read_only  = false

--- a/hcp-consul-hcp-vault-ca/modules/kubernetes/main.tf
+++ b/hcp-consul-hcp-vault-ca/modules/kubernetes/main.tf
@@ -241,16 +241,6 @@ resource "local_file" "add_iam_role" {
   filename = "./aws_auth.yaml"
 }
 
-# Render the IAM role file partial to add to the aws-auth configmap
-resource "local_file" "consul_values" {
-  content = templatefile("${path.module}/template_scripts/consul-values.tftpl", {
-    hcp_consul_addr = var.consul_http_addr
-    vault_addr = var.vault_addr
-    kube_control_plabe = var.consul_k8s_api_aws
-  })
-  filename = "./consul-values.yaml"
-}
-
 # Add the IAM role to the aws-auth configmap
 resource "null_resource" "add_iam_role" {
 

--- a/hcp-consul-hcp-vault-ca/modules/kubernetes/main.tf
+++ b/hcp-consul-hcp-vault-ca/modules/kubernetes/main.tf
@@ -139,7 +139,7 @@ resource "kubernetes_deployment" "workingEnvironment" {
           }
         }
         volume {
-          name = "consul-values.yaml"
+          name = "consul-values"
           config_map {
             name         = "consul-values.yaml"
             default_mode = "0755"
@@ -214,7 +214,7 @@ resource "kubernetes_deployment" "workingEnvironment" {
           }
           volume_mount {
             mount_path = "/root/consul-values.yaml"
-            name       = "consul-values.yaml"
+            name       = "consul-values"
             sub_path   = "consul-values.yaml"
             read_only  = false
           }

--- a/hcp-consul-hcp-vault-ca/modules/kubernetes/template_scripts/consul-values.tftpl
+++ b/hcp-consul-hcp-vault-ca/modules/kubernetes/template_scripts/consul-values.tftpl
@@ -1,0 +1,64 @@
+global:
+  name: consul
+  enabled: false
+  datacenter: dc1
+  image: hashicorp/consul-enterprise:1.11.4-ent
+  enableConsulNamespaces: true
+  acls:
+    manageSystemACLs: true
+    bootstrapToken:
+      secretName: consul-bootstrap-token
+      secretKey: token
+  gossipEncryption:
+    secretName: consul-gossip-key
+    secretKey: key
+  tls:
+    enabled: true
+    enableAutoEncrypt: true
+    caCert:
+      secretName: consul-ca-cert
+      secretKey: tls.crt
+externalServers:
+  enabled: true
+  hosts:
+  - ${hcp_consul_addr}
+  httpsPort: 443
+  useSystemRoots: true
+  k8sAuthMethodHost: ${kube_control_plane}
+client:
+  enabled: true
+  grpc: true
+  join:
+  - ${hcp_consul_addr}
+connectInject:
+  enabled: true
+  envoyExtraArgs: "--component-log-level upstream:debug,http:debug,router:debug,config:debug"
+  aclBindingRuleSelector: ''
+  consulNamespaces:
+    mirroringK8S: true
+  transparentProxy:
+    defaultEnabled: false
+controller:
+  enabled: true
+secretsBackend:
+  vault:
+    enabled: true
+    # https://www.consul.io/docs/k8s/helm#v-global-secretsbackend-vault-consulclientrole
+    consulClientRole: consul-consul-client
+    consulCARole: consul-consul-client
+    # https://www.consul.io/docs/k8s/helm#v-global-secretsbackend-vault-connectca
+    connectCA:
+      address: ${vault_addr}
+      rootPKIPath: /connect_root
+      intermediatePKIPath: /connect_inter
+      additionalConfig: |
+        {
+          "connect": [{
+            "ca_config": [{
+              "leaf_cert_ttl": "72h",
+              "intermediate_cert_ttl": "8760h",
+              "rotation_period": "2160h",
+              "namespace": "admin"
+            }]
+          }]
+        }

--- a/hcp-consul-hcp-vault-ca/modules/kubernetes/template_scripts/consul-values.tftpl
+++ b/hcp-consul-hcp-vault-ca/modules/kubernetes/template_scripts/consul-values.tftpl
@@ -1,7 +1,7 @@
 global:
   name: consul
   enabled: false
-  datacenter: dc1
+  datacenter: ${datacenter}
   image: hashicorp/consul-enterprise:1.11.4-ent
   enableConsulNamespaces: true
   acls:

--- a/hcp-consul-hcp-vault-ca/modules/kubernetes/variables.tf
+++ b/hcp-consul-hcp-vault-ca/modules/kubernetes/variables.tf
@@ -141,3 +141,8 @@ variable "kube_context" {
   description = "The name of the kube context to set in the config file for kubectl"
 }
 
+variable "consul_datacenter" {
+  type = string
+  description = "The name of the Consul datacenter"
+}
+

--- a/hcp-consul-hcp-vault-ca/provider.tf
+++ b/hcp-consul-hcp-vault-ca/provider.tf
@@ -14,9 +14,6 @@ terraform {
 
 provider "aws" {
   region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
 }
 
 provider "hcp" {}

--- a/hcp-consul-hcp-vault-ca/set_region_for_makefile.sh
+++ b/hcp-consul-hcp-vault-ca/set_region_for_makefile.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+TF_VAR_region=$(read -p "Enter the AWS Region to use for this project (e.g. us-east-1) > ")
+
+if [ ! $TF_VAR_region ]; then
+  # Set val if user skips entering any intput, and default to us-east-1
+  TF_VAR_region="us-east-1"
+  echo "region=\"${TF_VAR_region}\"" > terraform.tfvars
+  echo "hcp_region=\"${TF_VAR_region}\"" >> terraform.tfvars
+fi
+
+exit 0

--- a/hcp-consul-hcp-vault-ca/variables.tf
+++ b/hcp-consul-hcp-vault-ca/variables.tf
@@ -1,6 +1,27 @@
 variable "region" {
-  default     = "us-east-1"
-  description = "Region in which to run this terraform code for the AWS Provider"
+  description = "AWS Region to deploy this terraform code"
+  validation {
+    condition = contains([
+      "eu-north-1",
+      "ap-south-1",
+      "eu-west-3",
+      "eu-west-2",
+      "eu-west-1",
+      "ap-northeast-3",
+      "ap-northeast-2",
+      "ap-northeast-1",
+      "sa-east-1",
+      "ca-central-1",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "eu-central-1",
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2"
+    ], var.region)
+    error_message = "The name of the region you entered is invalid. Please try again. \n Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html ."
+  }
 }
 
 variable "node_group_configuration" {

--- a/hcp-consul-hcp-vault-ca/variables.tf
+++ b/hcp-consul-hcp-vault-ca/variables.tf
@@ -37,12 +37,6 @@ variable "node_group_configuration" {
   }
 }
 
-variable "availability_zones" {
-  description = "Availability Zones for the EKS Cluster deployed in main.tf"
-  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  type        = list(string)
-}
-
 variable "default_tags" {
   type        = map(string)
   description = "Default tags to pass to AWS resources"
@@ -81,7 +75,6 @@ variable "hcp_peering_identifier" {
 variable "hcp_region" {
   description = "HCP region for HCP-created resources"
   type        = string
-  default     = "us-east-1"
 }
 
 variable "cloud_provider" {
@@ -104,7 +97,6 @@ variable "hcp_vault_cluster_name" {
 
 variable "cluster_and_vpc_info" {
   default = {
-    region             = "us-east-1"
     name               = "tutorialCluster"
     vpc_name           = "hcpTutorialAwsVpc"
     policy_name        = "workingenvironmentpolicy"

--- a/hcp-consul-hcp-vault-ca/working-environment/main.tf
+++ b/hcp-consul-hcp-vault-ca/working-environment/main.tf
@@ -18,4 +18,5 @@ module "kubernetes" {
   cluster_service_account_name = var.cluster_service_account_name
   cluster_name = var.cluster_name
   cluster_region = var.cluster_region
+  consul_datacenter = var.consul_datacenter
 }

--- a/hcp-consul-hcp-vault-ca/working-environment/variables.tf
+++ b/hcp-consul-hcp-vault-ca/working-environment/variables.tf
@@ -88,3 +88,8 @@ variable "cluster_service_account_name" {
   type = string
   description = "Service account name for the Pod"
 }
+
+variable "consul_datacenter" {
+  type = string
+  description = "Name of the HCP Consul datacenter"
+}


### PR DESCRIPTION
There were some blockers that prevent successful deployment:

* Unique names were not enforced
* kubeconfig generation wasn't consistent
* kube cluster context wasn't set right


Added:

* programmatic generation of consul-values
* makefile for easier deployment