### PR TITLE
Admin Partition: Update ClusterRoleBinding apiVersion 

### DIFF
--- a/consul-enterprise-admin-partitions-eks/eks-admin-service-account.yaml
+++ b/consul-enterprise-admin-partitions-eks/eks-admin-service-account.yaml
@@ -7,7 +7,7 @@ metadata:
   name: eks-admin
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eks-admin


### PR DESCRIPTION
...in eks-admin-service-account.yaml

I was following the admin partition tutorial that uses tag v0.0.19. 

When deploying the infrastructure using `terraform apply -auto-approve`, Terraform throws an error: 

```
Error running command 'kubectl apply -f eks-admin-service-account.yaml': exit status 1. Output: serviceaccount/eks-admin created
│ error: resource mapping not found for name: "eks-admin" namespace: "" from "eks-admin-service-account.yaml": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
│ ensure CRDs are installed first
```

Update apiVersion from beta to v1 solves this problem.